### PR TITLE
Fix axios config comment path

### DIFF
--- a/cloudmart-frontend/src/config/axiosConfig.js
+++ b/cloudmart-frontend/src/config/axiosConfig.js
@@ -1,4 +1,4 @@
-// src/utils/axiosConfig.js
+// src/config/axiosConfig.js
 import axios from 'axios';
 
 const instance = axios.create({


### PR DESCRIPTION
## Summary
- correct axiosConfig.js leading comment to match the path

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_6863fba667f0832bb2722a448b90a975