### PR TITLE
Fix DynamoDB typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Cloud Mart aims to:
 - RESTful APIs
 
 **Database:**
-- DyanmoDB
+- DynamoDB
 
 **Cloud Providers:**
 - AWS (DynamoDB, Bedrock, S3, EC2, Lambda, CloudWatch, EKS, ECS)


### PR DESCRIPTION
## Summary
- fix a typo in the Technology Stack section of README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` in backend *(fails: missing test script)*

------
https://chatgpt.com/codex/tasks/task_e_6863fb965f70832bbe6cdc760eec9574